### PR TITLE
Format Found Error for GH Annotation Instead

### DIFF
--- a/check-ray-calls.sh
+++ b/check-ray-calls.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
-RESULTS=`grep -r --include "*.php" "\W@\?ray(" ./app ./resources/views ./database ./routes ./tests`
+RESULTS=`grep -r -n --include "*.php" "\W@\?ray(" ./app ./resources/views ./database ./routes ./tests`
 
 if [[ ! -z "$RESULTS" ]]; then
-  echo "Found some ray() calls..."
-  echo "${RESULTS}"
+  while read -r line; do
+    FILE_PATH=`echo $line | sed -E 's/^(.*):([0-9]+): ray\((.*)\);$/\1/'`
+    LINE_NUMBER=`echo $line | sed -E 's/^(.*):([0-9]+): ray\((.*)\);$/\2/'`
+    RAY_CONTENT=`echo $line | sed -E 's/^(.*):([0-9]+): ray\((.*)\);$/\3/'`
+    MESSAGE="Found ray($RAY_CONTENT) in $FILE_PATH on line $LINE_NUMBER"
+
+    echo "::error file=$FILE_PATH,line=$LINE_NUMBER::$MESSAGE";
+
+  done <<< "$RESULTS"
   exit 1
-else
-  echo "No ray() calls found !"
 fi


### PR DESCRIPTION
For a use-case when I'd use this more often is within my Pull Requests. So what this PR does is parses through the results and build a output compatible with GitHub's annotations. This is similar (and where I found the extract way to output) as `cs2pr`.

Wondering if this might be more helpful to users rather then printing in the action console.
Below is an example:
![image](https://user-images.githubusercontent.com/25044744/230264987-52f8b7d1-778c-49c6-bc7b-6e3afacaf14d.png)

This is the link to [cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle/blob/master/cs2pr#L141) annotation writter.
